### PR TITLE
ALTERNATELY: Fix for hauling minified buildings -

### DIFF
--- a/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
@@ -242,7 +242,7 @@ namespace PickUpAndHaul
             Map map = pawn.Map;
             KeyValuePair<IntVec3, CellAllocation> allocation = storeCellCapacity.FirstOrDefault(kvp => 
                 kvp.Key.GetSlotGroup(map).parent.Accepts(nextThing) && 
-                kvp.Value.allocated.CanStackWith(nextThing));
+                (nextThing == kvp.Value.allocated || kvp.Value.allocated.CanStackWith(nextThing)));
             IntVec3 storeCell = allocation.Key;
 
             //Can't stack with allocated cells, find a new cell:


### PR DESCRIPTION
The first thing's store cell is already allocated, so it would check if it can stack with itself when adding it to the queue. Simply check if the allocated thing is itself as well.