### PR TITLE
Use global WorkGiver DB instead of pawn's work list - 

### DIFF
--- a/Source/PickUpAndHaul/JobDriver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/JobDriver_HaulToInventory.cs
@@ -114,7 +114,7 @@ namespace PickUpAndHaul
                     LocalTargetInfo storeCell = curJob.targetB;
 
                     List<Thing> haulables = actor.Map.listerHaulables.ThingsPotentiallyNeedingHauling();
-                    WorkGiver_HaulToInventory haulMoreWork = actor.workSettings.WorkGiversInOrderNormal.First(wg => wg is WorkGiver_HaulToInventory) as WorkGiver_HaulToInventory;
+                    WorkGiver_HaulToInventory haulMoreWork = DefDatabase<WorkGiverDef>.AllDefsListForReading.First(wg => wg.Worker is WorkGiver_HaulToInventory).Worker as WorkGiver_HaulToInventory;
                     Thing haulMoreThing = GenClosest.ClosestThing_Global(actor.Position, haulables, 12, t => haulMoreWork.HasJobOnThing(actor, t, false));
 
                     //WorkGiver_HaulToInventory found more work nearby


### PR DESCRIPTION
just in case they're doing work they're not normally capable of.