### PR TITLE
Fix compatibiltiy with Common Sense and Misc Robots++

### DIFF
--- a/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
@@ -50,6 +50,11 @@ namespace PickUpAndHaul
 
             DesignationDef haulUrgentlyDesignation = DefDatabase<DesignationDef>.GetNamed("HaulUrgentlyDesignation", false);
 
+            // Misc. Robots compatibility 
+            // See https://github.com/catgirlfighter/RimWorld_CommonSense/blob/master/Source/CommonSense11/CommonSense/OpportunisticTasks.cs#L129-L140
+            if (pawn.TryGetComp<CompHauledToInventory>() == null) 
+                return null;
+
             //This WorkGiver gets hijacked by AllowTool and expects us to urgently haul corpses.
             if (ModCompatibilityCheck.AllowToolIsActive && thing is Corpse
                 && pawn.Map.designationManager.DesignationOn(thing)?.def == haulUrgentlyDesignation && HaulAIUtility.PawnCanAutomaticallyHaulFast(pawn, thing, forced))


### PR DESCRIPTION
Fix #34 

Fix bug where Misc. Robots would try to Pick Up and Haul to construct/craft while 
Common Sense is also active, and cause an error because they don't have 
CompHauledToInventory.